### PR TITLE
Fixed broken gradle repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
     repositories {
-        maven {
-            url 'http://dev.proactive.li:8081/artifactory/plugins-release'
-        }
+        maven { url "https://plugins.gradle.org/m2/" }
+        mavenCentral()
     }
     dependencies {
         classpath 'com.moowork.gradle:gradle-node-plugin:0.12'
@@ -11,9 +10,8 @@ buildscript {
 }
 
 repositories {
-    maven {
-        url 'http://dev.proactive.li:8081/artifactory/libs-release'
-    }
+    maven { url "https://plugins.gradle.org/m2/" }
+    mavenCentral()
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
The original configuration used some private, non-DNS resolvable repositories. Using standard repos fixes the build.
